### PR TITLE
Implement potential search

### DIFF
--- a/viewer/quiverFtns.js
+++ b/viewer/quiverFtns.js
@@ -688,7 +688,7 @@ function getAllMutationsForQP(qp, maxMutationsToFind) {
             var mutatedStr = stringifyQP(mutated)
             if (!alreadySeen.includes(mutatedStr)) {
                 alreadySeen.push(mutatedStr)
-                chains.push(chain)
+                chains.push(chain + qp.nodes[i])
                 collectMutations(mutated, chain + qp.nodes[i])
             }
         }
@@ -796,13 +796,14 @@ function potentialSearch(qp, searchExchangeNum, testRate=0.2) {
             }
 
             var qpt = deepCopy(qp)
-            qpt.potential = deepCopy(template).filter(t => t[0] !== 0);
+            var constructedPotential = deepCopy(template).filter(t => t[0] !== 0);
+            qpt.potential = constructedPotential
             try {
                 var exchangeNum = getAllMutationsForQP(qpt, searchExchangeNum + 1).quivers.length
             } catch (e) {
                 console.log(e)
                 errored++;
-                erroredResults.push(deepCopy(template))
+                erroredResults.push(constructedPotential)
             }
             if (exchangeNumBuckets[exchangeNum]) {
                 exchangeNumBuckets[exchangeNum]++;
@@ -811,16 +812,16 @@ function potentialSearch(qp, searchExchangeNum, testRate=0.2) {
             }
             if (exchangeNum === searchExchangeNum) {
                 succeeded++;
-                succeededResults.push(deepCopy(template));
+                succeededResults.push(constructedPotential);
             } else {
                failed++;
-               failedResults.push(deepCopy(template))
+               failedResults.push(constructedPotential)
             }
 
             if (!resultsByExchangeNum[exchangeNum]) {
                 resultsByExchangeNum[exchangeNum] = []
             }
-            resultsByExchangeNum[exchangeNum].push(deepCopy(template))
+            resultsByExchangeNum[exchangeNum].push(constructedPotential)
 
             tested++;
            // console.log(tested);

--- a/viewer/quiverFtns.js
+++ b/viewer/quiverFtns.js
@@ -756,14 +756,14 @@ function potentialSearch(qp, searchExchangeNum) {
     var cyclesWithoutQuadratics = findAllCycles(qp).filter(cycle => cycle.length > 2)
 
     cyclesWithoutQuadratics = cyclesWithoutQuadratics.concat([
-        "8,9,10",
-        "2,6,7,3",
-        "0,1,17,16",
-        "6,8,7"
+        [8, 9, 10],
+        [2, 6, 7, 3],
+        [0, 1, 17, 16],
+        [6, 8, 7]
     ])
 
     var potentialTemplate = cyclesWithoutQuadratics.map(cycle => {
-        return [0, cycle]
+        return [0, cycle.join(",")]
     })
     console.log(cyclesWithoutQuadratics)
 
@@ -785,6 +785,7 @@ function potentialSearch(qp, searchExchangeNum) {
             try {
                 var exchangeNum = getAllMutationsForQP(qpt, searchExchangeNum + 1).quivers.length
             } catch (e) {
+                console.log(e)
                 failed++;
             }
             if (exchangeNumBuckets[exchangeNum]) {

--- a/viewer/quiverFtns.js
+++ b/viewer/quiverFtns.js
@@ -411,6 +411,7 @@ function draw() {
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 function allThreeCycles (QP) {
     var triples = [];
+    let alreadySeen = []
     for (let v1 in QP.nodes) {
         let arrowsOut1 = QP.arrowsWithTail[v1];
 
@@ -437,8 +438,9 @@ function allThreeCycles (QP) {
 
                             if (v4 == v1) {
                                 let triple = cycleOrder([e1i, e2i, e3i]).toString();
-                                if (!triples.includes(triple)) {
+                                if (!alreadySeen.includes(triple)) {
                                     triples.push([e1i,e2i,e3i]);
+                                    alreadySeen.push([e1i,e2i,e3i].toString());
                                 }
                             }
                         }
@@ -736,17 +738,22 @@ function findAllCycles(qp) {
         collectCyles(qp, node, node, [], []);
     }
 
+   // cycles = cycles.map(cycle => cycle.sort())
+
+    cycles = cycles.filter(function(cycle, idx) {
+        for(var idx2 = 0; idx2 < idx; idx2++) {
+            if (JSON.stringify(cycleOrder(cycles[idx])) === JSON.stringify(cycles[idx2])) {
+                return false;
+            }
+        }
+        return true;
+    })
+
     return cycles;
 }
 
 function potentialSearch(qp, searchExchangeNum) {
     var cyclesWithoutQuadratics = findAllCycles(qp).filter(cycle => cycle.length > 2)
-
-    //remove duplicate cycles
-    cyclesWithoutQuadratics = cyclesWithoutQuadratics.map(i => i.sort().join(",")).sort()
-    console.log(cyclesWithoutQuadratics)
-
-    cyclesWithoutQuadratics = cyclesWithoutQuadratics.filter((cycle, idx) => cyclesWithoutQuadratics.indexOf(cycle) === idx)
 
     cyclesWithoutQuadratics = cyclesWithoutQuadratics.concat([
         "8,9,10",
@@ -793,7 +800,7 @@ function potentialSearch(qp, searchExchangeNum) {
             }
             tested++;
            // console.log(tested);
-            if (tested % 100 === 0) {
+            if (tested % 1000 === 0) {
                 console.log("%: ", tested / totalToTest, failed)
             }
         } else {

--- a/viewer/quiverFtns.js
+++ b/viewer/quiverFtns.js
@@ -332,6 +332,35 @@ function draw() {
         { id: "16", from: "5", to: "0", arrows: "to", title: "edge 16"},
         { id: "17", from: "0", to: "5", arrows: "to", title: "edge 17"},
     ]);
+
+    //assigns each self-loop a unique radius so that they don't overlap
+    function updateEdgeRadii(id) {
+        var thisEdge = edges.get(id);
+
+        if (thisEdge.from === thisEdge.to) {
+            var count = edges.get().filter(function (otherEdge) {
+                return otherEdge.from === thisEdge.from & otherEdge.to === thisEdge.to && parseInt(otherEdge.id) < parseInt(thisEdge.id)
+            }).length
+
+            thisEdge.selfReference = {
+                size: 15 + (count * 5)
+            }
+
+            edges.update(thisEdge)
+        }
+    }
+
+    //update the initial dataset
+
+    edges.get().forEach(edge => updateEdgeRadii(edge.id))
+
+    //and whenever an edge is added
+    edges.on("add", function (event, properties, senderId) {
+        properties.items.forEach(function(i) {
+            updateEdgeRadii(i);
+        })
+    })
+
     frozen_nodes = new vis.DataSet();
     frozen_nodes.on("*", function () {
     document.getElementById("frozen_nodes").innerText = JSON.stringify(


### PR DESCRIPTION
This code attempts to search through "all" of the possible potentials and find the possible exchange numbers for a given quiver. There's no UI in the applet, but to use it from the devtools:

```
var qp = makeQP(edges, nodes, frozen_nodes, potential)
var result = potentialSearch(qp, maxExchangeNum, maxCycleLength, testRate);
```

Where:
* maxExchangeNum = largest possible exchange number to look for
* maxCycleLength - only potential terms <= this length are tested
  * Larger terms _should_ be testable, but when I tried to enable this, the mutation code would sometimes get stuck in an infinite loop when given very long potential terms.
* testRate - fraction of possible potentials to test

Suggested usage for the default quiver:
```
potentialSearch(qp, 50, 5, 0.0001)
```

Limitations:
1. Cycles with multiple self-loops are not tested.
  - It should be possible to enable this, but I ran into the same issue with the mutation code hanging when I did so.
3. "figure-8" cycles are not automatically included. (such as 2,6,7,3). The potentialSearch code manually adds 2,6,7,3 and 0,1,17,16 to the list of terms to test before running; these should be modified when performing the search on a different quiver.
4. Each term is only tested with coefficients [0, 1, 2.5]